### PR TITLE
2.0.0 release documentation updates

### DIFF
--- a/docs/Aerospike-access-control.md
+++ b/docs/Aerospike-access-control.md
@@ -3,6 +3,36 @@ title: Aerospike Access Control
 description: Aerospike Access Control
 ---
 
+## Enable security
+To use Aerospike Access control you need to enable security for the Aerospike clusters.
+
+### Aerospike server 5.7.x and later
+Enable security for your Aerospike clusters in aerospikeConfig section of the CR like so
+```yaml
+  aerospikeConfig:
+    .
+    .
+    .
+    security: {}
+    .
+    .
+    .
+```
+
+### Aerospike server 5.6.x and prior
+Enable security for your Aerospike clusters in aerospikeConfig section of the CR like so
+```yaml
+  aerospikeConfig:
+    .
+    .
+    .
+    security: 
+      enable-security: true
+    .
+    .
+    .
+```
+
 Aerospike Access Control includes user, role, and privilege creation and maintenance. [See the documentation for more information on Aerospike Access Control](https://docs.aerospike.com/docs/operations/configure/security/access-control/index.html).
 
 To manage your access controls from the operator, configure the `aerospikeAccessControl` section in the Aerospike cluster's Custom Resource (CR) file.
@@ -10,7 +40,6 @@ To manage your access controls from the operator, configure the `aerospikeAccess
 :::warning
 Access control changes on an operator-managed Aerospike cluster will be reverted if made externally (e.g. using `aql` or `asadm`).
 :::
-
 
 Here are a few examples for common access control tasks:
 

--- a/docs/Aerospike-configuration-mapping.md
+++ b/docs/Aerospike-configuration-mapping.md
@@ -203,8 +203,7 @@ YAML
 service:
   proto-fd-max: 15000
 
-security:
-  enable-security: true
+security: {}
 
 logging:
   - name: console

--- a/docs/Cluster-configuration-settings.md
+++ b/docs/Cluster-configuration-settings.md
@@ -5,14 +5,14 @@ description: Cluster Configuration Settings
 
 Aerospike cluster configuration settings are in the Aerospike cluster Custom Resource (CR). You can edit this file to make changes to your Aerospike cluster.
 
-The [Operator Custom Resource Definition (CRD)](https://github.com/aerospike/aerospike-kubernetes-operator/blob/master/config/crd/bases/asdb.aerospike.com_aerospikeclusters.yaml) specifies the CR the Operator uses to manage the cluster.
+The [Operator Custom Resource Definition (CRD)](https://github.com/aerospike/aerospike-kubernetes-operator/blob/2.0.0/config/crd/bases/asdb.aerospike.com_aerospikeclusters.yaml) specifies the CR the Operator uses to manage the cluster.
 
 
 ## Example CR
 
 This basic CR is included as an example to get you started. It creates a simple cluster with no storage, using data-in-memory (DIM).
 
-For a more realistic and more complicated real-world example, we recommend the [example rack-enabled cluster CR](https://github.com/aerospike/aerospike-kubernetes-operator/blob/master/config/samples/rack_enabled_cluster_cr.yaml).
+For a more realistic and more complicated real-world example, we recommend the [example rack-enabled cluster CR](https://github.com/aerospike/aerospike-kubernetes-operator/blob/2.0.0/config/samples/rack_enabled_cluster_cr.yaml).
 
 These and other example CRs are stored in [the main Aerospike Kubernetes Operator repository](https://github.com/aerospike/aerospike-kubernetes-operator/tree/master/config/samples).
 
@@ -24,7 +24,7 @@ metadata:
   namespace: aerospike
 spec:
   size: 2
-  image: aerospike/aerospike-server-enterprise:5.6.0.7
+  image: aerospike/aerospike-server-enterprise:5.7.0.8
 
   podSpec:
     multiPodPerHost: true
@@ -64,8 +64,7 @@ spec:
         clustering: debug
     service:
       feature-key-file: /etc/aerospike/secret/features.conf
-    security:
-      enable-security: true
+    security: {}
     network:
       service:
         port: 3000

--- a/docs/Create-Aerospike-cluster.md
+++ b/docs/Create-Aerospike-cluster.md
@@ -60,7 +60,7 @@ You can edit the CR file at any time to make changes and manage the Aerospike cl
 
 Use the custom resource YAML file you created to deploy an Aerospike cluster. If you don't have a custom resource file, you can choose one of the sample files in the main Aerospike Kubernetes Operator repository](https://github.com/aerospike/aerospike-kubernetes-operator/tree/master/config/samples).
 
-For example, to use the [dim_nostorage_cluster_cr.yaml](https://github.com/aerospike/aerospike-kubernetes-operator/blob/master/config/samples/dim_nostorage_cluster_cr.yaml) file, download it and apply it to your cluster with:
+For example, to use the [dim_nostorage_cluster_cr.yaml](https://github.com/aerospike/aerospike-kubernetes-operator/blob/2.0.0/config/samples/dim_nostorage_cluster_cr.yaml) file, download it and apply it to your cluster with:
 
 ```shell
 kubectl apply -f dim_nostorage_cluster_cr.yaml

--- a/docs/Data-on-SSD.md
+++ b/docs/Data-on-SSD.md
@@ -46,8 +46,7 @@ To set this up, add the following storage-specific configuration to the Aerospik
   aerospikeConfig:
     service:
       feature-key-file: /etc/aerospike/secret/features.conf
-    security:
-      enable-security: true
+    security: {}
     namespaces:
       - name: test
         memory-size: 3000000000
@@ -58,7 +57,7 @@ To set this up, add the following storage-specific configuration to the Aerospik
             - /test/dev/xvdf
 ```
 
-For the full CR file, see the [example SSD storage cluster CR](https://github.com/aerospike/aerospike-kubernetes-operator/blob/master/config/samples/ssd_storage_cluster_cr.yaml).
+For the full CR file, see the [example SSD storage cluster CR](https://github.com/aerospike/aerospike-kubernetes-operator/blob/2.0.0/config/samples/ssd_storage_cluster_cr.yaml).
 
 This and other example CRs are stored in [the main Aerospike Kubernetes Operator repository](https://github.com/aerospike/aerospike-kubernetes-operator/tree/master/config/samples).
 

--- a/docs/HDD-storage-with-data-in-index.md
+++ b/docs/HDD-storage-with-data-in-index.md
@@ -49,8 +49,7 @@ To set this up, add the following storage-specific configuration to the Aerospik
   aerospikeConfig:
     service:
       feature-key-file: /etc/aerospike/secret/features.conf
-    security:
-      enable-security: true
+    security: {}
     namespaces:
       - name: test
         memory-size: 2000000000
@@ -76,7 +75,7 @@ To set this up, add the following storage-specific configuration to the Aerospik
           data-in-memory: true
 ```
 
-For the full CR file, see the [example HDD storage with data-in-index cluster CR](https://github.com/aerospike/aerospike-kubernetes-operator/blob/master/config/samples/hdd_dii_storage_cluster_cr.yaml).
+For the full CR file, see the [example HDD storage with data-in-index cluster CR](https://github.com/aerospike/aerospike-kubernetes-operator/blob/2.0.0/config/samples/hdd_dii_storage_cluster_cr.yaml).
 
 This and other example CRs are stored in [the main Aerospike Kubernetes Operator repository](https://github.com/aerospike/aerospike-kubernetes-operator/tree/master/config/samples).
 

--- a/docs/HDD-storage-with-data-in-memory.md
+++ b/docs/HDD-storage-with-data-in-memory.md
@@ -41,8 +41,7 @@ To set this up, add the following storage-specific configuration to the Aerospik
   aerospikeConfig:
     service:
       feature-key-file: /etc/aerospike/secret/features.conf
-    security:
-      enable-security: true
+    security: {}
     namespace:
       - name: test
         memory-size: 3000000000
@@ -55,7 +54,7 @@ To set this up, add the following storage-specific configuration to the Aerospik
           data-in-memory: true
 ```
 
-For the full CR file, see the [example HDD storage with data-in-memory cluster CR](https://github.com/aerospike/aerospike-kubernetes-operator/blob/master/config/samples/hdd_dim_storage_cluster_cr.yaml).
+For the full CR file, see the [example HDD storage with data-in-memory cluster CR](https://github.com/aerospike/aerospike-kubernetes-operator/blob/2.0.0/config/samples/hdd_dim_storage_cluster_cr.yaml).
 
 This and other example CRs are stored in [the main Aerospike Kubernetes Operator repository](https://github.com/aerospike/aerospike-kubernetes-operator/tree/master/config/samples).
 

--- a/docs/Install-the-Operator-on-Kubernetes.md
+++ b/docs/Install-the-Operator-on-Kubernetes.md
@@ -52,7 +52,7 @@ You will always install the Operator on a single namespace. However, the Operato
 To install the Operator on the `aerospike` namespace, and only use it to manage the `aerospike` namespace, run the Operator bundle with the command:
 
 ```shell
-operator-sdk run bundle docker.io/aerospike/aerospike-kubernetes-operator-bundle:2.0.0-rc2 --namespace=aerospike
+operator-sdk run bundle docker.io/aerospike/aerospike-kubernetes-operator-bundle:2.0.0 --namespace=aerospike
 ```
 
 ### Manage Multiple Specific Namespaces
@@ -62,7 +62,7 @@ Use `--install-mode MultiNamespace=[namespace 1],[namespace 1],[etc]` to manage 
 For example, to install the Operator on the `aerospike` namespace and use it to manage Aerospike clusters on the `ns1` and `ns2` namespaces, the command is:
 
 ```shell
-operator-sdk run bundle docker.io/aerospike/aerospike-kubernetes-operator-bundle:2.0.0-rc2 --namespace=aerospike --install-mode MultiNamespace=ns1,ns2
+operator-sdk run bundle docker.io/aerospike/aerospike-kubernetes-operator-bundle:2.0.0 --namespace=aerospike --install-mode MultiNamespace=ns1,ns2
 ```
 
 ### Manage All Namespaces
@@ -70,7 +70,7 @@ operator-sdk run bundle docker.io/aerospike/aerospike-kubernetes-operator-bundle
 Use `--install-mode AllNamespaces` to manage Aerospike clusters on all available namespaces:
 
 ```shell
-operator-sdk run bundle docker.io/aerospike/aerospike-kubernetes-operator-bundle:2.0.0-rc2 --namespace=aerospike --install-mode AllNamespaces
+operator-sdk run bundle docker.io/aerospike/aerospike-kubernetes-operator-bundle:2.0.0 --namespace=aerospike --install-mode AllNamespaces
 ```
 
 ## RBAC
@@ -85,7 +85,7 @@ Use `kubectl get csv -n aerospike` to verify the Operator's CSV is in the `Succe
 $ kubectl get csv -n aerospike
 
 NAME                                       DISPLAY                         VERSION     REPLACES   PHASE
-aerospike-kubernetes-operator.v2.0.0-rc2   Aerospike Kubernetes operator   2.0.0-rc2              Succeeded
+aerospike-kubernetes-operator.v2.0.0   Aerospike Kubernetes operator   2.0.0              Succeeded
 
 ```
 

--- a/docs/Install-the-Operator-on-Kubernetes.md
+++ b/docs/Install-the-Operator-on-Kubernetes.md
@@ -97,7 +97,7 @@ $ kubectl get pod -n aerospike
 NAME                                                              READY   STATUS      RESTARTS   AGE
 5af02cb7676a864fa68cc875fb1bc64df2f1223ab355b4911792e9--1-vlltn   0/1     Completed   0          63s
 aerospike-operator-controller-manager-55d45754bf-smzxc            2/2     Running     0          48s
-ker-io-aerospike-aerospike-kubernetes-operator-bundle-2-0-0-rc1   1/1     Running     0          73s
+ker-io-aerospike-aerospike-kubernetes-operator-bundle-2-0-0       1/1     Running     0          73s
 
 ```
 

--- a/docs/Kubernetes-Secrets.md
+++ b/docs/Kubernetes-Secrets.md
@@ -35,7 +35,6 @@ For example, suppose that you want to give two people access to the Aerospike cl
 spec:
   .
   .
-  enable-security: true
   .
   aerospikeAccessControl:
     users:

--- a/docs/Manage-TLS-Certificates.md
+++ b/docs/Manage-TLS-Certificates.md
@@ -45,8 +45,7 @@ Next, add the TLS-specific configuration to the Aerospike cluster's CR file.
   aerospikeConfig:
     service:
       feature-key-file: /etc/aerospike/secret/features.conf
-    security:
-      enable-security: true
+    security: {}
     network:
       service:
         tls-name: aerospike-a-0.test-runner
@@ -66,7 +65,7 @@ Next, add the TLS-specific configuration to the Aerospike cluster's CR file.
 
 ```
 
-For the full CR file, see the [example TLS cluster CR](https://github.com/aerospike/aerospike-kubernetes-operator/blob/master/config/samples/tls_cluster_cr.yaml).
+For the full CR file, see the [example TLS cluster CR](https://github.com/aerospike/aerospike-kubernetes-operator/blob/2.0.0/config/samples/tls_cluster_cr.yaml).
 
 This and other example CRs are stored in [the main Aerospike Kubernetes Operator repository](https://github.com/aerospike/aerospike-kubernetes-operator/tree/master/config/samples).
 

--- a/docs/Multiple-Aerospike-clusters.md
+++ b/docs/Multiple-Aerospike-clusters.md
@@ -25,16 +25,16 @@ Next, add this service account to the Operator's `ClusterRoleBinding`. To do thi
 
 ```shell
 kubectl get clusterrolebindings.rbac.authorization.k8s.io  | grep aerospike-kubernetes-operator
-aerospike-kubernetes-operator.v2.0.0-rc2-74b946466d                 ClusterRole/aerospike-kubernetes-operator.v2.0.0-rc2-74b946466d   41m
+aerospike-kubernetes-operator.v2.0.0-74b946466d                 ClusterRole/aerospike-kubernetes-operator.v2.0.0-74b946466d   41m
 ```
 
-In this example, the name of the cluster role binding is `aerospike-kubernetes-operator.v2.0.0-rc2-74b946466d`
+In this example, the name of the cluster role binding is `aerospike-kubernetes-operator.v2.0.0-74b946466d`
 
 Use kubectl to edit the role binding and add a new subject entry for the service account:
 
 ```shell
-# Replace aerospike-kubernetes-operator.v2.0.0-rc2-74b946466d with the name of the cluster role binding found above
-kubectl edit clusterrolebindings.rbac.authorization.k8s.io  aerospike-kubernetes-operator.v2.0.0-rc2-74b946466d
+# Replace aerospike-kubernetes-operator.v2.0.0-74b946466d with the name of the cluster role binding found above
+kubectl edit clusterrolebindings.rbac.authorization.k8s.io  aerospike-kubernetes-operator.v2.0.0-74b946466d
 ```
 
 This command launches an editor. Append the following lines to the `subjects` section:
@@ -57,17 +57,17 @@ kind: ClusterRoleBinding
 metadata:
   creationTimestamp: "2021-09-16T10:48:36Z"
   labels:
-    olm.owner: aerospike-kubernetes-operator.v2.0.0-rc2
+    olm.owner: aerospike-kubernetes-operator.v2.0.0
     olm.owner.kind: ClusterServiceVersion
     olm.owner.namespace: test
     operators.coreos.com/aerospike-kubernetes-operator.test: ""
-  name: aerospike-kubernetes-operator.v2.0.0-rc2-74b946466d
+  name: aerospike-kubernetes-operator.v2.0.0-74b946466d
   resourceVersion: "51841234"
   uid: be546dd5-b21e-4cc3-8a07-e2fe5fe5274c
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: aerospike-kubernetes-operator.v2.0.0-rc2-74b946466d
+  name: aerospike-kubernetes-operator.v2.0.0-74b946466d
 subjects:
   - kind: ServiceAccount
     name: aerospike-operator-controller-manager

--- a/docs/Rack-Awareness.md
+++ b/docs/Rack-Awareness.md
@@ -51,8 +51,7 @@ This example adds Rack Awareness to an existing Aerospike cluster CR file.
   aerospikeConfig:
     service:
       feature-key-file: /etc/aerospike/secret/features.conf
-    security:
-      enable-security: true
+    security: {}
     namespaces:
       - name: test
         memory-size: 3000000000
@@ -76,7 +75,7 @@ Save and exit the CR file, then use kubectl to apply the change.
 kubectl apply -f aerospike-cluster.yaml
 ```
 
-For the full CR file, see the [example rack-enabled cluster CR](https://github.com/aerospike/aerospike-kubernetes-operator/blob/master/config/samples/rack_enabled_cluster_cr.yaml).
+For the full CR file, see the [example rack-enabled cluster CR](https://github.com/aerospike/aerospike-kubernetes-operator/blob/2.0.0/config/samples/rack_enabled_cluster_cr.yaml).
 
 This and other example CRs are stored in [the main Aerospike Kubernetes Operator repository](https://github.com/aerospike/aerospike-kubernetes-operator/tree/master/config/samples).
 
@@ -209,8 +208,7 @@ As an example, here is the original rack-local aerospikeConfig and common global
   aerospikeConfig:
     service:
       feature-key-file: /etc/aerospike/secret/features.conf
-    security:
-      enable-security: true
+    security: {}
     namespaces:
       - name: test
         memory-size: 3000000000
@@ -235,8 +233,7 @@ After merging the rack-local aerospikeConfig with the common global aerospikeCon
     service:
       proto-fd-max: 18000
       feature-key-file: /etc/aerospike/secret/features.conf
-    security:
-      enable-security: true
+    security: {}
     namespaces:
       - name: test
         memory-size: 3000000000

--- a/docs/Scaling-namespace-storage.md
+++ b/docs/Scaling-namespace-storage.md
@@ -57,8 +57,7 @@ spec:
   aerospikeConfig:
     service:
       feature-key-file: /etc/aerospike/secret/features.conf
-    security:
-      enable-security: true
+    security: {}
     namespaces:
       - name: test
         memory-size: 6000000000
@@ -127,8 +126,7 @@ spec:
   aerospikeConfig:
     service:
       feature-key-file: /etc/aerospike/secret/features.conf
-    security:
-      enable-security: true
+    security: {}
     namespaces:
       - name: test
         memory-size: 10000000000

--- a/docs/Shadow-device.md
+++ b/docs/Shadow-device.md
@@ -55,8 +55,7 @@ Next, add the following storage-specific configuration to the Aerospike cluster'
   aerospikeConfig:
     service:
       feature-key-file: /etc/aerospike/secret/features.conf
-    security:
-      enable-security: true
+    security: {}
     namespaces:
       - name: test
         memory-size: 3000000000
@@ -67,7 +66,7 @@ Next, add the following storage-specific configuration to the Aerospike cluster'
             - /dev/nvme0n1 /dev/sdf
 ```
 
-For the full CR file, see the [example shadow device cluster CR](https://github.com/aerospike/aerospike-kubernetes-operator/blob/master/config/samples/shadow_device_cluster_cr.yaml).
+For the full CR file, see the [example shadow device cluster CR](https://github.com/aerospike/aerospike-kubernetes-operator/blob/2.0.0/config/samples/shadow_device_cluster_cr.yaml).
 
 This and other example CRs are stored in [the main Aerospike Kubernetes Operator repository](https://github.com/aerospike/aerospike-kubernetes-operator/tree/master/config/samples).
 

--- a/docs/Storage-provisioning.md
+++ b/docs/Storage-provisioning.md
@@ -55,9 +55,9 @@ To automate the local volume provisioning, we will create and run a provisioner 
 
 The provisioner runs as a DaemonSet which manages the local SSDs on each node based on a discovery directory, creates and deletes the PersistentVolumes, and cleans up the storage when it is released.
 
-The local volume static provisioner for this example is defined in [aerospike_local_volume_provisioner.yaml](https://github.com/aerospike/aerospike-kubernetes-operator/tree/2.0.0-rc2/config/samples/storage/aerospike_local_volume_provisioner.yaml).
+The local volume static provisioner for this example is defined in [aerospike_local_volume_provisioner.yaml](https://github.com/aerospike/aerospike-kubernetes-operator/tree/2.0.0/config/samples/storage/aerospike_local_volume_provisioner.yaml).
 
-The storage class is defined in [local_storage_class.yaml](https://github.com/aerospike/aerospike-kubernetes-operator/blob/master/config/samples/storage/local_storage_class.yaml). This and other example CRs are stored in [the main Aerospike Kubernetes Operator repository](https://github.com/aerospike/aerospike-kubernetes-operator/tree/master/config/samples).
+The storage class is defined in [local_storage_class.yaml](https://github.com/aerospike/aerospike-kubernetes-operator/blob/2.0.0/config/samples/storage/local_storage_class.yaml). This and other example CRs are stored in [the main Aerospike Kubernetes Operator repository](https://github.com/aerospike/aerospike-kubernetes-operator/tree/master/config/samples).
 
 Create local storage class, then deploy the provisioner.
 

--- a/docs/Warm-restart.md
+++ b/docs/Warm-restart.md
@@ -1,0 +1,19 @@
+---
+title: Warm restart
+description: Warm restart Aerospike Server on Aerospike configuration change 
+---
+
+Aerospike operator 2.0.0 allows for warm restart of Aerospike pods on changes to the Aerospike server configuration in the [Aerospike Config Section](Cluster-configuration-settings.md#aerospike-config) of your custom resource.
+This feature requires Aerospike server container images that use [tini](https://github.com/aerospike/tini) as the `init` process. 
+
+## Aerospike Server 5.7.0.9 and later
+Container images for Aerospike enterprise server 5.7.0.9 and later use tini init by default and will warm restart on Aerospike configuration changes.  
+
+## Aerospike Server 5.7.0.8 and prior
+For Aerospike enterprise server 5.7.0.8 and prior, container images that use tini have been tagged with the prefix 'tinistaticbackport'.
+
+E.g.
+
+```yaml
+aerospike/aerospike-server-enterprise:tinistaticbackport-5.7.0.8
+```

--- a/docs/XDR.md
+++ b/docs/XDR.md
@@ -56,8 +56,7 @@ storage:
     service:
       feature-key-file: /etc/aerospike/secret/features.conf
 
-    security:
-      enable-security: true
+    security: {}
 
     network:
       service:
@@ -91,7 +90,7 @@ storage:
 
 ```
 
-For the full CR file, see the [example XDR CR](https://github.com/aerospike/aerospike-kubernetes-operator/blob/master/config/samples/xdr_src_cluster_cr.yaml).
+For the full CR file, see the [example XDR CR](https://github.com/aerospike/aerospike-kubernetes-operator/blob/2.0.0/config/samples/xdr_src_cluster_cr.yaml).
 
 This and other example CRs are stored in [the main Aerospike Kubernetes Operator repository](https://github.com/aerospike/aerospike-kubernetes-operator/tree/master/config/samples).
 

--- a/docs/all-flash.md
+++ b/docs/all-flash.md
@@ -103,7 +103,7 @@ spec:
             - /test/dev/xvdf
 ```
 
-For the full CR file, see the [example all-flash cluster CR](https://github.com/aerospike/aerospike-kubernetes-operator/blob/master/config/samples/all_flash_cluster_cr.yaml).
+For the full CR file, see the [example all-flash cluster CR](https://github.com/aerospike/aerospike-kubernetes-operator/blob/2.0.0/config/samples/all_flash_cluster_cr.yaml).
 
 This and other example CRs are stored in [the main Aerospike Kubernetes Operator repository](https://github.com/aerospike/aerospike-kubernetes-operator/tree/master/config/samples).
 

--- a/docs/install-operator-helm.md
+++ b/docs/install-operator-helm.md
@@ -29,6 +29,7 @@ To get the Helm charts, clone the `aerospike/aerospike-kubernetes-operator` repo
 
 ```sh
 git clone https://github.com/aerospike/aerospike-kubernetes-operator.git
+git checkout 2.0.0
 ```
 
 The charts are in the `aerospike-kubernetes-operator/helm-charts` folder.

--- a/docs/install-operator-helm.md
+++ b/docs/install-operator-helm.md
@@ -50,8 +50,8 @@ helm install aerospike-kubernetes-operator ./aerospike-kubernetes-operator --set
 | Name       | Description | Default   |
 | ---------- | ----------- | --------- |
 | `replicas` | Number of operator replicas. | `2` |
-| `operatorImage.repository` | Operator image repository. | `aerospike/aerospike-kubernetes-operator-nightly` |
-| `operatorImage.tag` | Operator image tag. | `2.0.0-candidate-master-42` |
+| `operatorImage.repository` | Operator image repository. | `aerospike/aerospike-kubernetes-operator` |
+| `operatorImage.tag` | Operator image tag. | `2.0.0` |
 | `operatorImage.pullPolicy` | Image pull policy. | `IfNotPresent` |
 | `imagePullSecrets` | Secrets containing credentials to pull Operator image from a private registry. | `{}` (nil) |
 | `rbac.create` | Set this to `true` to let the Helm chart automatically create RBAC resources necessary for operator. | `true` |

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -103,9 +103,10 @@ module.exports = {
           routeBasePath: '/',
           // Please change this to your repo.
           editUrl: 'https://github.com/aerospike/kubernetes-operator/edit/main/',
+          lastVersion: 'current',
           versions: {
             current: {
-              label: "2.0.0-rc2 🚧"
+              label: "2.0.0"
             }
           }
         },

--- a/sidebars.json
+++ b/sidebars.json
@@ -91,6 +91,10 @@
           {
             "type": "doc",
             "id": "Aerospike-access-control"
+          },
+          {
+            "type": "doc",
+            "id": "Warm-restart"
           }
         ],
         "collapsible": true,


### PR DESCRIPTION
- Install instructions now use 2.0.0 images
- Samples link to 2.0.0 CRs in the operator repository
- New page on warm restart
- Access control has a new section on updating security